### PR TITLE
Scheduler - Recover failed jobs

### DIFF
--- a/src/Rescheduler.Core/Handlers/RecoverJobExecutionsHandler.cs
+++ b/src/Rescheduler.Core/Handlers/RecoverJobExecutionsHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Rescheduler.Core.Interfaces;
+
+namespace Rescheduler.Core.Handlers
+{
+    public class RecoverJobExecutionsHandler : IRequestHandler<RecoverJobExecutionsRequest, RecoverJobExecutionsResponse>
+    {
+        private readonly IJobExecutionRepository _jobExecutionsRepository;
+
+
+        public RecoverJobExecutionsHandler(IJobExecutionRepository jobExecutionsRepository)
+        {
+            _jobExecutionsRepository = jobExecutionsRepository;
+        }
+
+        public async Task<RecoverJobExecutionsResponse> Handle(RecoverJobExecutionsRequest request, CancellationToken ctx)
+        {
+            var numRecovered = await _jobExecutionsRepository.RecoverAsync(ctx);
+
+            return new RecoverJobExecutionsResponse(numRecovered);
+        }
+    }
+
+    public record RecoverJobExecutionsRequest() : IRequest<RecoverJobExecutionsResponse>;
+
+    public record RecoverJobExecutionsResponse(int NumRecovered);
+}

--- a/src/Rescheduler.Core/Handlers/SchedulePendingHandler.cs
+++ b/src/Rescheduler.Core/Handlers/SchedulePendingHandler.cs
@@ -24,7 +24,7 @@ namespace Rescheduler.Core.Handlers
 
         public async Task<SchedulePendingResponse> Handle(SchedulePendingRequest request, CancellationToken cancellationToken)
         {
-            var until = DateTime.UtcNow.AddSeconds(10);
+            var until = DateTime.UtcNow;
             var totalScheduled = 0;
 
             int numScheduled;

--- a/src/Rescheduler.Core/Interfaces/IScheduledJobsRepository.cs
+++ b/src/Rescheduler.Core/Interfaces/IScheduledJobsRepository.cs
@@ -8,6 +8,7 @@ namespace Rescheduler.Core.Interfaces
 {
     public interface IJobExecutionRepository
     {
-         Task<IEnumerable<JobExecution>> GetAndMarkPending(int max, DateTime until, CancellationToken ctx);
+        Task<int> RecoverAsync(CancellationToken ctx);
+        Task<IEnumerable<JobExecution>> GetAndMarkPending(int max, DateTime until, CancellationToken ctx);
     }
 }

--- a/src/Rescheduler.Worker/JobScheduler.cs
+++ b/src/Rescheduler.Worker/JobScheduler.cs
@@ -22,7 +22,10 @@ namespace Rescheduler.Worker
 
         protected override async Task ExecuteAsync(CancellationToken ctx)
         {
-            using var logScope = _logger.BeginScope("{service}", "JobScheduler");
+            // Wait for the service to start and apply pending db migrations
+            await Task.Delay(TimeSpan.FromSeconds(5), ctx);
+            
+            using var logScope = _logger.BeginScope("{Service}", "JobScheduler");
 
             await RecoverJobExecutionsAsync(ctx);
 

--- a/src/Rescheduler.Worker/JobScheduler.cs
+++ b/src/Rescheduler.Worker/JobScheduler.cs
@@ -24,22 +24,39 @@ namespace Rescheduler.Worker
         {
             using var logScope = _logger.BeginScope("{service}", "JobScheduler");
 
+            await RecoverJobExecutionsAsync(ctx);
+
             _logger.LogInformation("Job scheduler started");
 
+            await RunSchedulerAsync(ctx);
+
+            _logger.LogInformation("Job scheduler stopped");
+        }
+
+        private async Task RecoverJobExecutionsAsync(CancellationToken ctx)
+        {
+            using var scope = _scopeFactory.CreateScope();
+
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var recovered = await mediator.Send(new RecoverJobExecutionsRequest(), ctx);
+            
+            _logger.LogInformation("Recovered {NumExecutions} executions", recovered);
+        }
+
+        private async Task RunSchedulerAsync(CancellationToken ctx)
+        {
             while (!ctx.IsCancellationRequested)
             {
-                await Task.Delay(TimeSpan.FromSeconds(30), ctx);
+                await Task.Delay(TimeSpan.FromSeconds(3), ctx);
 
                 // Scope this part due to DbContext disposing etc.
                 using var scope = _scopeFactory.CreateScope();
-                
+
                 var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
                 var result = await mediator.Send(new SchedulePendingRequest(), ctx);
 
-                _logger.LogInformation("Queued {numbJobs} jobs", result.NumScheduled);
+                _logger.LogInformation("Queued {NumbJobs} jobs", result.NumScheduled);
             }
-
-            _logger.LogInformation("Job scheduler stopped");
         }
     }
 }

--- a/test/Rescheduler.Core.Tests/Handlers/RecoverJobExecutionsHandlerTests.cs
+++ b/test/Rescheduler.Core.Tests/Handlers/RecoverJobExecutionsHandlerTests.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Rescheduler.Core.Handlers;
+using Rescheduler.Core.Interfaces;
+using Shouldly;
+using Xunit;
+
+namespace Rescheduler.Core.Tests.Handlers
+{
+    public class RecoverJobExecutionsHandlerTests
+    {
+        private readonly IJobExecutionRepository _jobExecutionRepository;
+
+        private readonly RecoverJobExecutionsHandler _handler;
+
+        public RecoverJobExecutionsHandlerTests()
+        {
+            _jobExecutionRepository = Mock.Of<IJobExecutionRepository>();
+
+            _handler = new RecoverJobExecutionsHandler(_jobExecutionRepository);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(9999, 9999)]
+        [InlineData(int.MaxValue, int.MaxValue)]
+        public async Task GivenNumberOfFlightExecutions_WhenRecovering_ThenShouldReturnRecovered(int numInFlight, int numExpected)
+        {
+            // Given
+            Mock.Get(_jobExecutionRepository)
+                .Setup(x => x.RecoverAsync(CancellationToken.None))
+                .ReturnsAsync(numInFlight);
+            
+            // When
+            var result = await _handler.Handle(new(), CancellationToken.None);
+            
+            // Then
+            result.NumRecovered.ShouldBe(numExpected);
+        }
+    }
+}

--- a/test/Rescheduler.Infra.Tests/Data/JobExecutionsRepository/GetAndMarkPendingTests.cs
+++ b/test/Rescheduler.Infra.Tests/Data/JobExecutionsRepository/GetAndMarkPendingTests.cs
@@ -2,26 +2,15 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Logging;
-using Moq;
 using Rescheduler.Core.Entities;
 using Rescheduler.Infra.Data;
 using Shouldly;
 using Xunit;
 
-namespace Rescheduler.Infra.Tests.Data
+namespace Rescheduler.Infra.Tests.Data.JobExecutionsRepository
 {
-    public class RepositoryTests
+    public class GetAndMarkPendingTests : JobExecutionsRepositoryTests
     {
-        private readonly ILogger<Repository<JobExecution>> _logger;
-
-        public RepositoryTests()
-        {
-            _logger = Mock.Of<ILogger<Repository<JobExecution>>>();
-        }
-
         [Fact]
         public async Task GivenToBeScheduledJob_WhenMarkingPending_ShouldMarkAndReturn()
         {
@@ -74,26 +63,6 @@ namespace Rescheduler.Infra.Tests.Data
 
             // Then
             result.ShouldBeEmpty();
-        }
-
-        private static JobContext GetSeededJobContext(Job job, JobExecution jobExecution)
-        {
-            var contextOptions = new DbContextOptionsBuilder<JobContext>()
-                .UseInMemoryDatabase("test")
-                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-                .Options;
-            
-            var context = new JobContext(contextOptions);
-
-            context.Database.EnsureDeleted();
-            context.Database.EnsureCreated();
-
-            context.Add(job);
-            context.Add(jobExecution);
-
-            context.SaveChanges();
-
-            return context;
         }
     }
 }

--- a/test/Rescheduler.Infra.Tests/Data/JobExecutionsRepository/JobExecutionsRepositoryTests.cs
+++ b/test/Rescheduler.Infra.Tests/Data/JobExecutionsRepository/JobExecutionsRepositoryTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rescheduler.Core.Entities;
+using Rescheduler.Infra.Data;
+
+namespace Rescheduler.Infra.Tests.Data.JobExecutionsRepository
+{
+    public class JobExecutionsRepositoryTests
+    {
+        internal readonly ILogger<Repository<JobExecution>> _logger;
+
+        internal JobExecutionsRepositoryTests()
+        {
+            _logger = Mock.Of<ILogger<Repository<JobExecution>>>();
+        }
+
+        internal static JobContext GetSeededJobContext(Job job, JobExecution jobExecution)
+        {
+            var contextOptions = new DbContextOptionsBuilder<JobContext>()
+                .UseInMemoryDatabase("test")
+                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+                .Options;
+            
+            var context = new JobContext(contextOptions);
+
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            context.Add(job);
+            context.Add(jobExecution);
+
+            context.SaveChanges();
+
+            return context;
+        }
+    }
+}

--- a/test/Rescheduler.Infra.Tests/Data/JobExecutionsRepository/RecoverTests.cs
+++ b/test/Rescheduler.Infra.Tests/Data/JobExecutionsRepository/RecoverTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Rescheduler.Core.Entities;
+using Rescheduler.Infra.Data;
+using Shouldly;
+using Xunit;
+
+namespace Rescheduler.Infra.Tests.Data.JobExecutionsRepository
+{
+    public class RecoverTests : JobExecutionsRepositoryTests
+    {
+        [Fact]
+        public async Task GivenInFlightExecution_WhenRecovering_ShouldRecover()
+        {
+            // Given 
+            var job = new Job(Guid.NewGuid(), "webhooks", "test passed", true, DateTime.UtcNow, DateTime.MaxValue, null);
+            var jobExecution = new JobExecution(Guid.NewGuid(), job.RunAt, null, ExecutionStatus.InFlight, job);
+
+            using var context = GetSeededJobContext(job, jobExecution);
+            var repo = new Repository<JobExecution>(_logger, context);
+
+            // When
+            var result = await repo.RecoverAsync(CancellationToken.None);            
+
+            // Then
+            result.ShouldBe(1);
+        }
+    }
+}


### PR DESCRIPTION
Recover failed jobs at startup.

When the scheduler experiences an unclean shutdown job executions might be stuck `in-flight`. When starting the scheduler first recover all `in-flight` executions by updating them to be `scheduled`