### PR TITLE
Update non-framework packages

### DIFF
--- a/src/Rescheduler.Api/Rescheduler.Api.csproj
+++ b/src/Rescheduler.Api/Rescheduler.Api.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
     <PackageReference Include="prometheus-net.SystemMetrics" Version="2.0.0" />
   </ItemGroup>

--- a/src/Rescheduler.Core/Rescheduler.Core.csproj
+++ b/src/Rescheduler.Core/Rescheduler.Core.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Cronos" Version="0.7.1" />
-    <PackageReference Include="MediatR" Version="11.0.0" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Rescheduler.Infra/Rescheduler.Infra.csproj
+++ b/src/Rescheduler.Infra/Rescheduler.Infra.csproj
@@ -9,16 +9,16 @@
     <ProjectReference Include="..\Rescheduler.Core\Rescheduler.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.4.16" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.7" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.83" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.8" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
     <PackageReference Include="prometheus-net" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />

--- a/test/Rescheduler.Api.Tests/Rescheduler.Api.Tests.csproj
+++ b/test/Rescheduler.Api.Tests/Rescheduler.Api.Tests.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Rescheduler.Core.Tests/Rescheduler.Core.Tests.csproj
+++ b/test/Rescheduler.Core.Tests/Rescheduler.Core.Tests.csproj
@@ -11,12 +11,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.1.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rescheduler.Core\Rescheduler.Core.csproj" />

--- a/test/Rescheduler.Infra.Tests/Rescheduler.Infra.Tests.csproj
+++ b/test/Rescheduler.Infra.Tests/Rescheduler.Infra.Tests.csproj
@@ -11,13 +11,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.8" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rescheduler.Core\Rescheduler.Core.csproj" />

--- a/test/Rescheduler.Worker.Tests/Rescheduler.Worker.Tests.csproj
+++ b/test/Rescheduler.Worker.Tests/Rescheduler.Worker.Tests.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
```
» Rescheduler.Api
  [net7.0]
  Swashbuckle.AspNetCore  6.4.0 -> 6.5.0

» Rescheduler.Api.Tests
  [net7.0]
  coverlet.collector  3.1.2  -> 3.2.0 
  Moq                 4.18.2 -> 4.18.4
  Shouldly            4.1.0  -> 4.2.1 

» Rescheduler.Core
  [net7.0]
  MediatR                                           11.0.0 -> 11.1.0
  MediatR.Extensions.Microsoft.DependencyInjection  11.0.0 -> 11.1.0

» Rescheduler.Core.Tests
  [net7.0]
  coverlet.collector  3.1.2  -> 3.2.0 
  Moq                 4.18.2 -> 4.18.4
  Shouldly            4.1.0  -> 4.2.1 

» Rescheduler.Infra
  [net7.0]
  AWSSDK.Extensions.NETCore.Setup   3.7.2    -> 3.7.7     
  AWSSDK.SimpleNotificationService  3.7.4.16 -> 3.7.101.83
  Azure.Messaging.ServiceBus        7.10.0   -> 7.15.0    
  RabbitMQ.Client                   6.4.0    -> 6.5.0     

» Rescheduler.Infra.Tests
  [net7.0]
  coverlet.collector  3.1.2  -> 3.2.0 
  Moq                 4.18.2 -> 4.18.4
  Shouldly            4.1.0  -> 4.2.1 

» Rescheduler.Worker.Tests
  [net7.0]
  coverlet.collector  3.1.2  -> 3.2.0 
  Moq                 4.18.2 -> 4.18.4
  Shouldly            4.1.0  -> 4.2.1
```